### PR TITLE
refactor: remove dom-if, support custom components

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -14,6 +14,8 @@
   <script src="./menu-bar-demo.js"></script>
 
   <link rel="import" href="../vaadin-menu-bar.html">
+  <link rel="import" href="../../iron-icon/iron-icon.html">
+  <link rel="import" href="../../vaadin-lumo-styles/icons.html">
 
   <custom-style>
     <style include="vaadin-component-demo-shared-styles"></style>

--- a/demo/menu-bar-basic-demos.html
+++ b/demo/menu-bar-basic-demos.html
@@ -87,12 +87,12 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Custom Menu Buttons</h3>
-    <vaadin-demo-snippet id="menu-bar-basic-demos-custom-buttons" when-defined="vaadin-menu-bar">
+    <h3>Using Components in Menu Buttons</h3>
+    <vaadin-demo-snippet id="menu-bar-basic-demos-components-buttons" when-defined="vaadin-menu-bar">
       <template preserve-content>
         <vaadin-menu-bar></vaadin-menu-bar>
         <script>
-          window.addDemoReadyListener('#menu-bar-basic-demos-custom-buttons', function(document) {
+          window.addDemoReadyListener('#menu-bar-basic-demos-components-buttons', function(document) {
             const menu = document.querySelector('vaadin-menu-bar');
             const makeIcon = function(icon) {
               const element = window.document.createElement('iron-icon');

--- a/demo/menu-bar-basic-demos.html
+++ b/demo/menu-bar-basic-demos.html
@@ -87,6 +87,31 @@
       </template>
     </vaadin-demo-snippet>
 
+    <h3>Custom Menu Buttons</h3>
+    <vaadin-demo-snippet id="menu-bar-basic-demos-custom-buttons" when-defined="vaadin-menu-bar">
+      <template preserve-content>
+        <vaadin-menu-bar></vaadin-menu-bar>
+        <script>
+          window.addDemoReadyListener('#menu-bar-basic-demos-custom-buttons', function(document) {
+            const menu = document.querySelector('vaadin-menu-bar');
+            menu.items = [
+              {
+                text: 'Project',
+                component: 'button',
+                children: [
+                  {text: 'Users'},
+                  {text: 'Billing'}
+                ]
+              },
+              {text: 'Account', component: 'button'},
+              {text: 'Sign Out', component: 'button'}
+            ];
+          });
+        </script>
+      </template>
+    </vaadin-demo-snippet>
+
+
   </template>
   <script>
     class MenuBarBasicDemos extends DemoReadyEventEmitter(MenuBarDemo(Polymer.Element)) {

--- a/demo/menu-bar-basic-demos.html
+++ b/demo/menu-bar-basic-demos.html
@@ -94,17 +94,24 @@
         <script>
           window.addDemoReadyListener('#menu-bar-basic-demos-custom-buttons', function(document) {
             const menu = document.querySelector('vaadin-menu-bar');
+            const makeIcon = function(icon) {
+              const element = window.document.createElement('iron-icon');
+              element.icon = icon;
+              return element;
+            };
             menu.items = [
               {
-                text: 'Project',
-                component: 'button',
-                children: [
-                  {text: 'Users'},
-                  {text: 'Billing'}
-                ]
+                component: makeIcon('lumo:plus'),
+                children: [{text: 'Create project'}, {text: 'Create report'}]
               },
-              {text: 'Account', component: 'button'},
-              {text: 'Sign Out', component: 'button'}
+              {
+                component: makeIcon('lumo:user'),
+                children: [{text: 'Users list'}, {text: 'Add user'}]
+              },
+              {
+                component: makeIcon('lumo:bell'),
+                children: [{text: 'Notifications'}, {text: 'Mark as read'}]
+              },
             ];
           });
         </script>

--- a/src/vaadin-menu-bar-button.html
+++ b/src/vaadin-menu-bar-button.html
@@ -16,37 +16,6 @@ This program is available under Apache License Version 2.0, available at https:/
       static get is() {
         return 'vaadin-menu-bar-button';
       }
-
-      static get properties() {
-        return {
-          item: {
-            type: Object,
-            value: () => {}
-          }
-        };
-      }
-
-      ready() {
-        super.ready();
-
-        this.addEventListener('click', e => this._dispatchClick(e));
-        this.addEventListener('keydown', e => e.keyCode === 40 && this._dispatchClick(e));
-      }
-
-      _focusWithKey() {
-        this.focus();
-        this.setAttribute('focus-ring', '');
-      }
-
-      _dispatchClick(e) {
-        e.stopPropagation();
-        const {item} = this;
-        this.dispatchEvent(new CustomEvent('button-click', {
-          detail: {item},
-          bubbles: true,
-          composed: true
-        }));
-      }
     }
 
     customElements.define(MenuBarButtonElement.is, MenuBarButtonElement);

--- a/src/vaadin-menu-bar-buttons-mixin.html
+++ b/src/vaadin-menu-bar-buttons-mixin.html
@@ -36,7 +36,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
     static get observers() {
       return [
-        '_buttonsRendered(items, items.splices)'
+        '_menuItemsChanged(items, items.splices)'
       ];
     }
 
@@ -46,22 +46,45 @@ This program is available under Apache License Version 2.0, available at https:/
       this.addEventListener('keydown', e => this._onKeydown(e));
       this.addEventListener('focusin', e => this._onFocusin(e));
       this.addEventListener('iron-resize', e => this.__onResize());
+
+      const container = this._container;
+
+      container.addEventListener('click', e => this._onItemClick(e));
+      container.addEventListener('keydown', e => e.keyCode === 40 && this._onItemClick(e));
     }
 
     get _buttons() {
-      return Array.from(this.shadowRoot.querySelectorAll('vaadin-menu-bar-button'));
+      return Array.from(this.shadowRoot.querySelectorAll('[part$="button"]'));
     }
 
-    _buttonsRendered(items, splices) {
+    get _container() {
+      return this.shadowRoot.querySelector('[part="container"]');
+    }
+
+    _menuItemsChanged(items, splices) {
       if (items.length) {
-        Polymer.RenderStatus.afterNextRender(this, () => {
+        if (items !== this._oldItems) {
+          this._oldItems = items;
+          this.__renderButtons(items);
           this.__detectOverflow();
-        });
+        }
+      }
+    }
+
+    _onItemClick(e) {
+      e.stopPropagation();
+      const button = Array.from(e.composedPath()).filter(el => el.item)[0];
+      if (button) {
+        button.dispatchEvent(new CustomEvent('button-click', {
+          detail: {item: button.item},
+          bubbles: true,
+          composed: true
+        }));
       }
     }
 
     _onFocusin(event) {
-      const target = this.shadowRoot.querySelector('vaadin-menu-bar-button[tabindex="0"]');
+      const target = this.shadowRoot.querySelector('[part$="button"][tabindex="0"]');
       if (target) {
         this._buttons.forEach(btn => {
           btn.tabIndex = btn === target ? 0 : -1;
@@ -106,7 +129,8 @@ This program is available under Apache License Version 2.0, available at https:/
         idx = this._getAvailableIndex(idx, increment, buttons);
         if (idx >= 0) {
           const btn = buttons[idx];
-          btn._focusWithKey();
+          btn.focus();
+          btn.setAttribute('focus-ring', '');
           buttons.forEach(e => e.tabIndex = e === btn ? 0 : -1);
           event.preventDefault();
         }
@@ -114,7 +138,7 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     __detectOverflow() {
-      const container = this.shadowRoot.querySelector('[part="container"]');
+      const container = this._container;
       const buttons = this._buttons.slice(0);
       const ellipsis = buttons.pop();
       const containerWidth = container.offsetWidth;
@@ -167,6 +191,37 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
       }
+    }
+
+    render() {
+      this.__renderButtons(this.items);
+    }
+
+    __renderButtons(items = []) {
+      const container = this._container;
+      const ellipsis = container.querySelector('[part="ellipsis-button"]');
+
+      while (container.children.length > 1) {
+        container.removeChild(container.firstElementChild);
+      }
+
+      items.forEach(item => {
+        let component;
+        if (item.component instanceof HTMLElement) {
+          component = item.component;
+        } else {
+          component = document.createElement(item.component || 'vaadin-menu-bar-button');
+        }
+        if (item.disabled) {
+          component.disabled = true;
+        }
+        component.setAttribute('part', 'menu-bar-button');
+        component.item = item;
+        if (item.text) {
+          component.textContent = item.text;
+        }
+        container.insertBefore(component, ellipsis);
+      });
     }
 
     __onResize() {

--- a/src/vaadin-menu-bar-buttons-mixin.html
+++ b/src/vaadin-menu-bar-buttons-mixin.html
@@ -151,7 +151,8 @@ This program is available under Apache License Version 2.0, available at https:/
         let i;
         for (i = buttons.length; i > 0; i--) {
           const btn = buttons[i - 1];
-          if (getComputedStyle(btn).visibility === 'hidden') {
+          const btnStyle = getComputedStyle(btn);
+          if (btnStyle.visibility === 'hidden') {
             continue;
           }
 
@@ -163,6 +164,8 @@ This program is available under Apache License Version 2.0, available at https:/
           btn.disabled = true;
           btn.style.visibility = 'hidden';
           btn.style.position = 'absolute';
+          // save width for buttons with component
+          btn.style.width = btnStyle.width;
         }
 
         ellipsis.item = {children: this.items.slice(i)};
@@ -181,6 +184,14 @@ This program is available under Apache License Version 2.0, available at https:/
             btn.disabled = false;
             btn.style.visibility = '';
             btn.style.position = '';
+            btn.style.width = '';
+
+            // teleport item component back from "ellipsis" sub-menu
+            const item = btn.item && btn.item.component;
+            if (item instanceof HTMLElement && item.classList.contains('vaadin-menu-item')) {
+              btn.appendChild(item);
+              item.classList.remove('vaadin-menu-item');
+            }
 
             ellipsis.item = {children: this.items.slice(i + 1)};
 
@@ -208,24 +219,39 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       items.forEach(item => {
-        let component;
-        if (item.component instanceof HTMLElement) {
-          component = item.component;
-        } else {
-          component = document.createElement(item.component || 'vaadin-menu-bar-button');
+        const button = document.createElement('vaadin-menu-bar-button');
+        button.item = item;
+
+        const itemComponent = item.component;
+        if (itemComponent) {
+          let component;
+          const isElement = itemComponent instanceof HTMLElement;
+          // use existing item component, if any
+          if (isElement && itemComponent.localName === 'vaadin-context-menu-item') {
+            component = itemComponent;
+          } else {
+            component = document.createElement('vaadin-context-menu-item');
+            component.appendChild(isElement ? itemComponent : document.createElement(itemComponent));
+          }
+          if (item.text) {
+            const node = component.firstChild || component;
+            node.textContent = item.text;
+          }
+          // save item for ellipsis menu
+          component.item = item;
+          button.item.component = component;
+          button.appendChild(component);
+        } else if (item.text) {
+          button.textContent = item.text;
         }
         if (item.disabled) {
-          component.disabled = true;
-          component.setAttribute('tabindex', '-1');
+          button.disabled = true;
+          button.setAttribute('tabindex', '-1');
         } else {
-          component.setAttribute('tabindex', '0');
+          button.setAttribute('tabindex', '0');
         }
-        component.setAttribute('part', 'menu-bar-button');
-        component.item = item;
-        if (item.text) {
-          component.textContent = item.text;
-        }
-        container.insertBefore(component, ellipsis);
+        button.setAttribute('part', 'menu-bar-button');
+        container.insertBefore(button, ellipsis);
       });
     }
 

--- a/src/vaadin-menu-bar-buttons-mixin.html
+++ b/src/vaadin-menu-bar-buttons-mixin.html
@@ -66,7 +66,6 @@ This program is available under Apache License Version 2.0, available at https:/
         if (items !== this._oldItems) {
           this._oldItems = items;
           this.__renderButtons(items);
-          this.__detectOverflow();
         }
       }
     }
@@ -257,6 +256,8 @@ This program is available under Apache License Version 2.0, available at https:/
         button.setAttribute('part', 'menu-bar-button');
         container.insertBefore(button, ellipsis);
       });
+
+      this.__detectOverflow();
     }
 
     __onResize() {

--- a/src/vaadin-menu-bar-buttons-mixin.html
+++ b/src/vaadin-menu-bar-buttons-mixin.html
@@ -170,6 +170,10 @@ This program is available under Apache License Version 2.0, available at https:/
           children: buttons.filter((b, idx) => idx >= i).map(b => b.item)
         };
       } else if (this._hasOverflow) {
+        if (this._subMenu.opened) {
+          this._subMenu.close();
+        }
+
         for (let i = 0; i < buttons.length; i++) {
           const btn = buttons[i];
 

--- a/src/vaadin-menu-bar-buttons-mixin.html
+++ b/src/vaadin-menu-bar-buttons-mixin.html
@@ -87,7 +87,7 @@ This program is available under Apache License Version 2.0, available at https:/
       const target = this.shadowRoot.querySelector('[part$="button"][tabindex="0"]');
       if (target) {
         this._buttons.forEach(btn => {
-          btn.tabIndex = btn === target ? 0 : -1;
+          btn.setAttribute('tabindex', btn === target ? '0' : '-1');
         });
       }
     }
@@ -131,7 +131,9 @@ This program is available under Apache License Version 2.0, available at https:/
           const btn = buttons[idx];
           btn.focus();
           btn.setAttribute('focus-ring', '');
-          buttons.forEach(e => e.tabIndex = e === btn ? 0 : -1);
+          buttons.forEach(e => {
+            e.setAttribute('tabindex', e === btn ? '0' : '-1');
+          });
           event.preventDefault();
         }
       }
@@ -214,6 +216,9 @@ This program is available under Apache License Version 2.0, available at https:/
         }
         if (item.disabled) {
           component.disabled = true;
+          component.setAttribute('tabindex', '-1');
+        } else {
+          component.setAttribute('tabindex', '0');
         }
         component.setAttribute('part', 'menu-bar-button');
         component.item = item;

--- a/src/vaadin-menu-bar-buttons-mixin.html
+++ b/src/vaadin-menu-bar-buttons-mixin.html
@@ -167,8 +167,9 @@ This program is available under Apache License Version 2.0, available at https:/
           // save width for buttons with component
           btn.style.width = btnStyle.width;
         }
-
-        ellipsis.item = {children: this.items.slice(i)};
+        ellipsis.item = {
+          children: buttons.filter((b, idx) => idx >= i).map(b => b.item)
+        };
       } else if (this._hasOverflow) {
         for (let i = 0; i < buttons.length; i++) {
           const btn = buttons[i];
@@ -193,7 +194,9 @@ This program is available under Apache License Version 2.0, available at https:/
               item.classList.remove('vaadin-menu-item');
             }
 
-            ellipsis.item = {children: this.items.slice(i + 1)};
+            ellipsis.item = {
+              children: buttons.filter((b, idx) => idx >= i + 1).map(b => b.item)
+            };
 
             if (btn === buttons[buttons.length - 1]) {
               this._hasOverflow = false;
@@ -220,7 +223,8 @@ This program is available under Apache License Version 2.0, available at https:/
 
       items.forEach(item => {
         const button = document.createElement('vaadin-menu-bar-button');
-        button.item = item;
+        const itemCopy = Object.assign({}, item);
+        button.item = itemCopy;
 
         const itemComponent = item.component;
         if (itemComponent) {
@@ -237,9 +241,9 @@ This program is available under Apache License Version 2.0, available at https:/
             const node = component.firstChild || component;
             node.textContent = item.text;
           }
+          itemCopy.component = component;
           // save item for ellipsis menu
-          component.item = item;
-          button.item.component = component;
+          component.item = itemCopy;
           button.appendChild(component);
         } else if (item.text) {
           button.textContent = item.text;

--- a/src/vaadin-menu-bar-sub-menu-mixin.html
+++ b/src/vaadin-menu-bar-sub-menu-mixin.html
@@ -70,7 +70,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
-    _itemsChanged(items, splices, isAttached) {
+    _itemsChanged(items, splices) {
       const subMenu = this._subMenu;
       if (subMenu && subMenu.opened) {
         subMenu.close();
@@ -82,7 +82,8 @@ This program is available under Apache License Version 2.0, available at https:/
       const list = item.parentNode;
       if (e.keyCode === 38 && item === list.items[0]) {
         this._close();
-        this._activeButton._focusWithKey();
+        this._activeButton.focus();
+        this._activeButton.setAttribute('focus-ring', '');
       }
     }
 

--- a/src/vaadin-menu-bar.html
+++ b/src/vaadin-menu-bar.html
@@ -5,8 +5,6 @@ This program is available under Apache License Version 2.0, available at https:/
 -->
 
 <link rel="import" href="../../polymer/polymer-element.html">
-<link rel="import" href="../../polymer/lib/elements/dom-if.html">
-<link rel="import" href="../../polymer/lib/elements/dom-repeat.html">
 <link rel="import" href="../../vaadin-themable-mixin/vaadin-themable-mixin.html">
 <link rel="import" href="../../vaadin-element-mixin/vaadin-element-mixin.html">
 <link rel="import" href="../../vaadin-context-menu/src/vaadin-context-menu.html">
@@ -44,11 +42,6 @@ This program is available under Apache License Version 2.0, available at https:/
     </style>
 
     <div part="container">
-      <template is="dom-repeat" items="[[items]]">
-        <vaadin-menu-bar-button disabled="[[item.disabled]]" item="[[item]]" part="menu-bar-button">
-          <span>[[item.text]]</span>
-        </vaadin-menu-bar-button>
-      </template>
       <vaadin-menu-bar-button part="ellipsis-button" hidden$="[[!_hasOverflow]]">...</vaadin-menu-bar-button>
     </div>
     <vaadin-context-menu

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -9,6 +9,12 @@
     "expect": false,
     "gemini": false,
     "MockInteractions": false,
+    "arrowUp": false,
+    "arrowDown": false,
+    "arrowLeft": false,
+    "arrowRight": false,
+    "home": false,
+    "end": false,
     "sinon": false
   }
 }

--- a/test/basic.html
+++ b/test/basic.html
@@ -209,6 +209,11 @@
         expect(ellipsis.item.children[1]).to.deep.equal(menu.items[3]);
       });
 
+      it('should show ellipsis button after calling render() with same items', () => {
+        menu.render();
+        expect(ellipsis.hasAttribute('hidden')).to.be.false;
+      });
+
       it('should show buttons and update ellipsis items when width increased', done => {
         menu.style.width = '350px';
         menu.notifyResize();

--- a/test/basic.html
+++ b/test/basic.html
@@ -6,6 +6,7 @@
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
+  <script src="./helpers.js"></script>
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../../polymer/lib/utils/render-status.html">
   <link rel="import" href="../vaadin-menu-bar.html">
@@ -19,22 +20,13 @@
   </test-fixture>
 
   <script>
-    function arrowRight(target) {
-      MockInteractions.keyDownOn(target, 39, [], 'ArrowRight');
+    function nextRender(target) {
+      return new Promise(resolve => {
+        Polymer.RenderStatus.afterNextRender(target, () => {
+          resolve();
+        });
+      });
     }
-
-    function arrowLeft(target) {
-      MockInteractions.keyDownOn(target, 37, [], 'ArrowLeft');
-    }
-
-    function home(target) {
-      MockInteractions.keyDownOn(target, 36, [], 'Home');
-    }
-
-    function end(target) {
-      MockInteractions.keyDownOn(target, 35, [], 'End');
-    }
-
 
     describe('custom element definition', () => {
       let menu;
@@ -59,18 +51,16 @@
     describe('root menu layout', () => {
       let menu, buttons;
 
-      beforeEach(done => {
+      beforeEach(async() => {
         menu = fixture('default');
         menu.items = [
           {text: 'Item 1'},
           {text: 'Item 2'},
           {text: 'Item 3', disabled: true},
-          {text: 'Item 4'},
+          {text: 'Item 4'}
         ];
-        Polymer.RenderStatus.afterNextRender(menu, () => {
-          buttons = menu._buttons;
-          done();
-        });
+        await nextRender(menu);
+        buttons = menu._buttons;
       });
 
       it('should render button for each item, plus ellipsis button', () => {
@@ -187,7 +177,7 @@
         expect(style.position).to.not.equal('absolute');
       };
 
-      beforeEach(done => {
+      beforeEach(async() => {
         menu = fixture('default');
 
         menu.style.width = '250px';
@@ -196,13 +186,11 @@
           {text: 'Item 1'},
           {text: 'Item 2'},
           {text: 'Item 3'},
-          {text: 'Item 4'},
+          {text: 'Item 4'}
         ];
-        Polymer.RenderStatus.afterNextRender(menu, () => {
-          buttons = menu._buttons;
-          ellipsis = buttons[buttons.length - 1];
-          done();
-        });
+        await nextRender(menu);
+        buttons = menu._buttons;
+        ellipsis = buttons[buttons.length - 1];
       });
 
       it('should show ellipsis button and hide the buttons which do not fit', () => {
@@ -259,6 +247,73 @@
           expect(ellipsis.item.children.length).to.equal(0);
           done();
         });
+      });
+    });
+
+    describe('item components', () => {
+      let menu, buttons, ellipsis;
+
+      function makeComponent(id) {
+        const div = document.createElement('div');
+        div.style.width = '100px';
+        div.textContent = `Item ${id}`;
+        return div;
+      }
+
+      beforeEach(async() => {
+        menu = fixture('default');
+        menu.items = [
+          {text: 'Item 1'},
+          {text: 'Item 2'},
+          {component: makeComponent('3')},
+          {text: 'Item 4 text', component: makeComponent('4')},
+          {text: 'Item 5', component: document.createElement('vaadin-context-menu-item')}
+        ];
+        await nextRender(menu);
+        buttons = menu._buttons;
+        ellipsis = buttons[buttons.length - 1];
+      });
+
+      it('should render the component inside the context-menu item', () => {
+        expect(buttons[2].firstChild.localName).to.equal('vaadin-context-menu-item');
+        const div = buttons[2].firstChild.firstChild;
+        expect(div.parentNode).to.equal(menu.items[2].component);
+        expect(div.localName).to.equal('div');
+        expect(div.textContent).to.equal('Item 3');
+        expect(getComputedStyle(div).width).to.equal('100px');
+      });
+
+      it('should override the component text when defined on the item', () => {
+        expect(buttons[3].firstChild.localName).to.equal('vaadin-context-menu-item');
+        const div = buttons[3].firstChild.firstChild;
+        expect(div.parentNode).to.equal(menu.items[3].component);
+        expect(div.localName).to.equal('div');
+        expect(div.textContent).to.equal('Item 4 text');
+        expect(getComputedStyle(div).width).to.equal('100px');
+      });
+
+      it('should render provided context-menu item as a component', () => {
+        expect(buttons[4].firstChild).to.equal(menu.items[4].component);
+        expect(buttons[4].firstChild.textContent).to.equal('Item 5');
+      });
+
+      it('should teleport the same component to ellipsis sub-menu and back', async() => {
+        menu.style.width = '250px';
+        menu.notifyResize();
+        await nextRender(menu);
+        const subMenu = menu._subMenu;
+        ellipsis.click();
+        await nextRender(subMenu);
+        const listBox = subMenu.$.overlay.querySelector('vaadin-context-menu-list-box');
+        expect(listBox.items[0]).to.equal(menu.items[2].component);
+        expect(listBox.items[0].firstChild.localName).to.equal('div');
+        subMenu.close();
+        menu.style.width = 'auto';
+        menu.notifyResize();
+        await nextRender(menu);
+        const item = buttons[2].firstChild;
+        expect(item).to.equal(menu.items[2].component);
+        expect(item.classList.contains('vaadin-menu-item')).to.be.false;
       });
     });
   </script>

--- a/test/basic.html
+++ b/test/basic.html
@@ -127,6 +127,8 @@
 
       it('should move focus to second button if first is disabled on "home" keydown', () => {
         menu.set('items.0.disabled', true);
+        menu.render();
+        buttons = menu._buttons;
         buttons[3].focus();
         const spy = sinon.spy(buttons[1], 'focus');
         home(buttons[3]);
@@ -144,6 +146,8 @@
 
       it('should move focus to the closest enabled button if last is disabled on "end" keydown', () => {
         menu.set('items.3.disabled', true);
+        menu.render();
+        buttons = menu._buttons;
         buttons[0].focus();
         const spy = sinon.spy(buttons[1], 'focus');
         end(buttons[0]);

--- a/test/basic.html
+++ b/test/basic.html
@@ -275,24 +275,29 @@
       });
 
       it('should render the component inside the context-menu item', () => {
-        expect(buttons[2].firstChild.localName).to.equal('vaadin-context-menu-item');
-        const div = buttons[2].firstChild.firstChild;
-        expect(div.parentNode).to.equal(menu.items[2].component);
+        const item = buttons[2].firstChild;
+        expect(item).to.equal(buttons[2].item.component);
+        expect(item.localName).to.equal('vaadin-context-menu-item');
+        const div = item.firstChild;
+        expect(div).to.equal(menu.items[2].component);
         expect(div.localName).to.equal('div');
         expect(div.textContent).to.equal('Item 3');
         expect(getComputedStyle(div).width).to.equal('100px');
       });
 
       it('should override the component text when defined on the item', () => {
-        expect(buttons[3].firstChild.localName).to.equal('vaadin-context-menu-item');
-        const div = buttons[3].firstChild.firstChild;
-        expect(div.parentNode).to.equal(menu.items[3].component);
+        const item = buttons[3].firstChild;
+        expect(item).to.equal(buttons[3].item.component);
+        expect(item.localName).to.equal('vaadin-context-menu-item');
+        const div = item.firstChild;
+        expect(div).to.equal(menu.items[3].component);
         expect(div.localName).to.equal('div');
         expect(div.textContent).to.equal('Item 4 text');
         expect(getComputedStyle(div).width).to.equal('100px');
       });
 
       it('should render provided context-menu item as a component', () => {
+        expect(buttons[4].item.component).to.equal(menu.items[4].component);
         expect(buttons[4].firstChild).to.equal(menu.items[4].component);
         expect(buttons[4].firstChild.textContent).to.equal('Item 5');
       });
@@ -305,14 +310,15 @@
         ellipsis.click();
         await nextRender(subMenu);
         const listBox = subMenu.$.overlay.querySelector('vaadin-context-menu-list-box');
-        expect(listBox.items[0]).to.equal(menu.items[2].component);
+        expect(listBox.items[0]).to.equal(buttons[2].item.component);
+        expect(listBox.items[0].firstChild).to.equal(menu.items[2].component);
         expect(listBox.items[0].firstChild.localName).to.equal('div');
         subMenu.close();
         menu.style.width = 'auto';
         menu.notifyResize();
         await nextRender(menu);
         const item = buttons[2].firstChild;
-        expect(item).to.equal(menu.items[2].component);
+        expect(item).to.equal(buttons[2].item.component);
         expect(item.classList.contains('vaadin-menu-item')).to.be.false;
       });
     });

--- a/test/basic.html
+++ b/test/basic.html
@@ -327,6 +327,19 @@
         expect(item).to.equal(buttons[2].item.component);
         expect(item.classList.contains('vaadin-menu-item')).to.be.false;
       });
+
+      it('should close the ellipsis sub-menu on resize', async() => {
+        menu.style.width = '200px';
+        menu.notifyResize();
+        await nextRender(menu);
+        const subMenu = menu._subMenu;
+        ellipsis.click();
+        await nextRender(subMenu);
+        menu.style.width = '300px';
+        menu.notifyResize();
+        await nextRender(subMenu);
+        expect(subMenu.opened).to.be.false;
+      });
     });
   </script>
 </body>

--- a/test/basic.html
+++ b/test/basic.html
@@ -302,9 +302,10 @@
       });
 
       it('should render provided context-menu item as a component', () => {
+        expect(buttons[4].firstChild).to.equal(buttons[4].item.component);
         expect(buttons[4].item.component).to.equal(menu.items[4].component);
-        expect(buttons[4].firstChild).to.equal(menu.items[4].component);
-        expect(buttons[4].firstChild.textContent).to.equal('Item 5');
+        expect(buttons[4].item.component.children.length).to.equal(0);
+        expect(buttons[4].item.component.textContent).to.equal('Item 5');
       });
 
       it('should teleport the same component to ellipsis sub-menu and back', async() => {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,23 @@
+window.arrowRight = function(target) {
+  MockInteractions.keyDownOn(target, 39, [], 'ArrowRight');
+};
+
+window.arrowLeft = function(target) {
+  MockInteractions.keyDownOn(target, 37, [], 'ArrowLeft');
+};
+
+window.arrowUp = function(target) {
+  MockInteractions.keyDownOn(target, 38, [], 'ArrowUp');
+};
+
+window.arrowDown = function(target) {
+  MockInteractions.keyDownOn(target, 40, [], 'ArrowDown');
+};
+
+window.home = function(target) {
+  MockInteractions.keyDownOn(target, 36, [], 'Home');
+};
+
+window.end = function(target) {
+  MockInteractions.keyDownOn(target, 35, [], 'End');
+};

--- a/test/sub-menu.html
+++ b/test/sub-menu.html
@@ -6,6 +6,7 @@
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
+  <script src="./helpers.js"></script>
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../../polymer/lib/utils/render-status.html">
   <link rel="import" href="../vaadin-menu-bar.html">
@@ -21,14 +22,6 @@
   <script>
     const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
 
-    function arrowUp(target) {
-      MockInteractions.keyDownOn(target, 38, [], 'ArrowUp');
-    }
-
-    function arrowDown(target) {
-      MockInteractions.keyDownOn(target, 40, [], 'ArrowDown');
-    }
-
     function nextRender(target) {
       return new Promise(resolve => {
         Polymer.RenderStatus.afterNextRender(target, () => {
@@ -40,7 +33,7 @@
     describe('sub-menu', () => {
       let menu, buttons, subMenu, item;
 
-      beforeEach(done => {
+      beforeEach(async() => {
         menu = fixture('default');
         menu.items = [
           {
@@ -59,11 +52,9 @@
             ]
           },
         ];
-        Polymer.RenderStatus.afterNextRender(menu, () => {
-          subMenu = menu._subMenu;
-          buttons = menu._buttons;
-          done();
-        });
+        await nextRender(menu);
+        subMenu = menu._subMenu;
+        buttons = menu._buttons;
       });
 
       afterEach(() => {

--- a/theme/lumo/vaadin-menu-bar-button-styles.html
+++ b/theme/lumo/vaadin-menu-bar-button-styles.html
@@ -3,6 +3,9 @@
 <dom-module id="lumo-menu-bar-button" theme-for="vaadin-menu-bar-button">
   <template>
     <style include="lumo-button">
+      :host ::slotted(vaadin-context-menu-item) {
+        padding: 0;
+      }
     </style>
   </template>
 </dom-module>

--- a/theme/material/vaadin-menu-bar-button-styles.html
+++ b/theme/material/vaadin-menu-bar-button-styles.html
@@ -3,6 +3,9 @@
 <dom-module id="material-menu-bar-button" theme-for="vaadin-menu-bar-button">
   <template>
     <style include="material-button">
+      :host ::slotted(vaadin-context-menu-item) {
+        padding: 0;
+      }
     </style>
   </template>
 </dom-module>


### PR DESCRIPTION
Fixes #18 

This also adds experimental support for custom root components requested in #13 
Note that "teleporting" root menu bar items into ellipsis sub-menu is not implemented.