### PR TITLE
fix: switch opened sub-menu on hover without open-on-hover

### DIFF
--- a/src/vaadin-menu-bar-buttons-mixin.html
+++ b/src/vaadin-menu-bar-buttons-mixin.html
@@ -93,7 +93,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
     _onMouseOver(e) {
       const button = Array.from(e.composedPath()).filter(el => el.item)[0];
-      if (this.openOnHover && button && button !== this._activeButton) {
+      if (button && button !== this._activeButton && (this.openOnHover || (button.item.children && this._subMenu.opened))) {
         this._dispatchClick(button);
       }
     }

--- a/test/sub-menu.html
+++ b/test/sub-menu.html
@@ -240,6 +240,16 @@
         await nextRender(subMenu);
         expect(subMenu.opened).to.be.false;
       });
+
+      it('should switch opened sub-menu on hover also when open-on-hover is false', async() => {
+        menu.openOnHover = false;
+        buttons[0].click();
+        await nextRender(subMenu);
+        buttons[2].dispatchEvent(new CustomEvent('mouseover', {bubbles: true, composed: true}));
+        await nextRender(subMenu);
+        expect(subMenu.opened).to.be.true;
+        expect(subMenu.listenOn).to.equal(buttons[2]);
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
Implemented the “change on hover” for menu opened on click, based on this logic:

1. `openOnHover = true`: 
  - hovering root menu item with children opens a sub-menu for it
  - hovering root menu item without children closes the sub-menu
2. `openOnHover = false`: 
  - after sub-menu opened on click, hovering other root menu item with children switches a sub-menu
  - hovering root menu item without children does NOT close the sub-menu (only click does)