### PR TITLE
fix: bump context-menu dependency and cleanup

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.2.0",
     "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.0.0",
     "vaadin-button": "vaadin/vaadin-button#^2.1.4",
-    "vaadin-context-menu": "vaadin/vaadin-context-menu#^4.3.2",
+    "vaadin-context-menu": "vaadin/vaadin-context-menu#^4.3.5",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.4.1",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.2.2"
   },

--- a/src/vaadin-menu-bar-interactions-mixin.html
+++ b/src/vaadin-menu-bar-interactions-mixin.html
@@ -257,13 +257,6 @@ This program is available under Apache License Version 2.0, available at https:/
             this.__openSubMenu(button, e, {keepFocus: true});
           }
         }
-      } else if ([38, 40].indexOf(e.keyCode) > -1) {
-        e.preventDefault();
-        if (e.keyCode === 38) {
-          this._focusLastItem();
-        } else {
-          this._focusFirstItem();
-        }
       }
     }
 

--- a/theme/lumo/vaadin-menu-bar-overlay-styles.html
+++ b/theme/lumo/vaadin-menu-bar-overlay-styles.html
@@ -4,10 +4,6 @@
       :host(:first-of-type) {
         padding-top: var(--lumo-space-xs);
       }
-
-      [part="overlay"] {
-        outline: none;
-      }
     </style>
   </template>
 </dom-module>

--- a/theme/material/vaadin-menu-bar-overlay-styles.html
+++ b/theme/material/vaadin-menu-bar-overlay-styles.html
@@ -4,10 +4,6 @@
       :host(:first-of-type) {
         padding-top: 5px;
       }
-
-      [part="overlay"] {
-        outline: none;
-      }
     </style>
   </template>
 </dom-module>


### PR DESCRIPTION
After vaadin/vaadin-context-menu#236 was released, some logic should be removed from menu-bar (as the tests are failing now on master) and the version should be bumped.