### PR TITLE
fix: ensure slotted context-menu item can be clicked

### DIFF
--- a/src/vaadin-menu-bar-button.html
+++ b/src/vaadin-menu-bar-button.html
@@ -4,8 +4,19 @@ Copyright (c) 2019 Vaadin Ltd.
 This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
 -->
 
-<link rel="import" href="../../polymer/polymer-element.html">
+<link rel="import" href="../../polymer/lib/elements/dom-module.html">
 <link rel="import" href="../../vaadin-button/src/vaadin-button.html">
+
+<dom-module id="vaadin-menu-bar-button-styles" theme-for="vaadin-menu-bar-button">
+  <template>
+    <style>
+      [part="label"] ::slotted(vaadin-context-menu-item) {
+        position: relative;
+        z-index: 1;
+      }
+    </style>
+  </template>
+</dom-module>
 
 <script>
   (function() {

--- a/test/basic.html
+++ b/test/basic.html
@@ -370,6 +370,13 @@
         await nextRender(subMenu);
         expect(subMenu.opened).to.be.false;
       });
+
+      it('should set position and z-index on the item component to allow clicks', () => {
+        const item = buttons[2].firstChild;
+        const style = getComputedStyle(item);
+        expect(style.position).to.equal('relative');
+        expect(Number(style.zIndex)).to.equal(1);
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
Fixes #29 

It turns out that slotted context-menu-item must have these styles in order to handle click events. 