### PR TITLE
fix: do not throw when calling render() before menu bar is attached

### DIFF
--- a/src/vaadin-menu-bar-buttons-mixin.html
+++ b/src/vaadin-menu-bar-buttons-mixin.html
@@ -168,6 +168,9 @@ This program is available under Apache License Version 2.0, available at https:/
      * any property on the item object corresponding to one of the menu bar buttons.
      */
     render() {
+      if (!this.shadowRoot) {
+        return;
+      }
       this.__renderButtons(this.items);
     }
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -161,6 +161,10 @@
         expect(buttons[3].hasAttribute('focused')).to.be.true;
       });
 
+      it('should not throw when render() is called before menu bar is attached', () => {
+        expect(() => document.createElement('vaadin-menu-bar').render()).to.not.throw(Error);
+      });
+
       describe('theme attribute', () => {
         it('should propagate theme attribute to all internal buttons', () => {
           menu.setAttribute('theme', 'contained');


### PR DESCRIPTION
Fixes #70 
Fixes vaadin/vaadin-menu-bar-flow#33