### PR TITLE
fix: extend context-menu to override global listener

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.2.0",
     "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.0.0",
     "vaadin-button": "vaadin/vaadin-button#^2.1.4",
-    "vaadin-context-menu": "vaadin/vaadin-context-menu#^4.3.5",
+    "vaadin-context-menu": "vaadin/vaadin-context-menu#^4.3.8",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.4.1",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.2.2"
   },

--- a/src/vaadin-menu-bar-interactions-mixin.html
+++ b/src/vaadin-menu-bar-interactions-mixin.html
@@ -202,7 +202,7 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     get _subMenu() {
-      return this.shadowRoot.querySelector('vaadin-context-menu');
+      return this.shadowRoot.querySelector('vaadin-menu-bar-submenu');
     }
 
     __alignOverlayPosition(e) {

--- a/src/vaadin-menu-bar-submenu.html
+++ b/src/vaadin-menu-bar-submenu.html
@@ -1,0 +1,35 @@
+<!--
+@license
+Copyright (c) 2019 Vaadin Ltd.
+This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+-->
+
+<link rel="import" href="../../vaadin-context-menu/src/vaadin-context-menu.html">
+
+<script>
+  (function() {
+    /**
+     * @memberof Vaadin
+     */
+    class MenuBarSubmenuElement extends Vaadin.ContextMenuElement {
+      static get is() {
+        return 'vaadin-menu-bar-submenu';
+      }
+
+      constructor() {
+        super();
+
+        this.openOn = 'opensubmenu';
+      }
+
+      /**
+       * Overriding the observer to not add global "contextmenu" listener.
+       */
+      _openedChanged(opened) {
+        this.$.overlay.opened = opened;
+      }
+    }
+
+    customElements.define(MenuBarSubmenuElement.is, MenuBarSubmenuElement);
+  })();
+</script>

--- a/src/vaadin-menu-bar.html
+++ b/src/vaadin-menu-bar.html
@@ -7,10 +7,10 @@ This program is available under Apache License Version 2.0, available at https:/
 <link rel="import" href="../../polymer/polymer-element.html">
 <link rel="import" href="../../vaadin-themable-mixin/vaadin-themable-mixin.html">
 <link rel="import" href="../../vaadin-element-mixin/vaadin-element-mixin.html">
-<link rel="import" href="../../vaadin-context-menu/src/vaadin-context-menu.html">
 <link rel="import" href="vaadin-menu-bar-button.html">
 <link rel="import" href="vaadin-menu-bar-buttons-mixin.html">
 <link rel="import" href="vaadin-menu-bar-interactions-mixin.html">
+<link rel="import" href="vaadin-menu-bar-submenu.html">
 
 <dom-module id="vaadin-menu-bar">
   <template>
@@ -52,9 +52,7 @@ This program is available under Apache License Version 2.0, available at https:/
         <div class="dots"></div>
       </vaadin-menu-bar-button>
     </div>
-    <vaadin-context-menu
-      open-on="opensubmenu">
-    </vaadin-context-menu>
+    <vaadin-menu-bar-submenu></vaadin-menu-bar-submenu>
   </template>
 
   <script>

--- a/test/sub-menu.html
+++ b/test/sub-menu.html
@@ -28,7 +28,6 @@
 
   <script>
     const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
-    const iOSVersion = isIOS && parseInt(navigator.appVersion.match(/OS (\d+)_(\d+)_?(\d+)?/)[1], 10);
 
     function nextRender(target) {
       return new Promise(resolve => {
@@ -606,8 +605,7 @@
       });
     });
 
-    // FIXME(yuriy): timed out in CI on iOS 10.3. Passing locally.
-    (iOSVersion === 10 ? describe.skip : describe)('touch', () => {
+    describe('touch', () => {
       let menu, buttons, subMenu, items, item;
 
       const open = (openTarget) => {

--- a/test/sub-menu.html
+++ b/test/sub-menu.html
@@ -304,6 +304,15 @@
         expect(spy.firstCall.args[0].detail.value).to.deep.equal({text: 'Menu Item 1 1'});
       });
 
+      it('should not close submenu on item contextmenu event', async() => {
+        buttons[0].click();
+        await nextRender(subMenu);
+        item = subMenu.$.overlay.querySelector('vaadin-context-menu-item');
+        item.dispatchEvent(new CustomEvent('contextmenu', {bubbles: true, composed: true}));
+        await nextRender(subMenu);
+        expect(subMenu.opened).to.be.true;
+      });
+
       (isIOS ? it.skip : it)('should not close on parent item click', async() => {
         arrowUp(buttons[0]);
         await onceOpened(subMenu);
@@ -657,7 +666,7 @@
         arrowDown(buttons[0]);
         await onceOpened(subMenu);
         await nextRender(subMenu);
-        const subMenu2 = subMenu.$.overlay.querySelector('vaadin-context-menu');
+        const subMenu2 = subMenu.$.overlay.querySelector('vaadin-menu-bar-submenu');
         subMenu2._touch = true;
         items = subMenu.$.overlay.querySelectorAll('vaadin-context-menu-item');
         item = items[items.length - 1];
@@ -674,13 +683,13 @@
         arrowDown(buttons[0]);
         await onceOpened(subMenu);
         await nextRender(subMenu);
-        const subMenu2 = subMenu.$.overlay.querySelector('vaadin-context-menu');
+        const subMenu2 = subMenu.$.overlay.querySelector('vaadin-menu-bar-submenu');
         subMenu2._touch = true;
         items = subMenu.$.overlay.querySelectorAll('vaadin-context-menu-item');
         item = items[items.length - 1];
         open(item);
         await nextRender(subMenu2);
-        const subMenu3 = subMenu2.$.overlay.querySelector('vaadin-context-menu');
+        const subMenu3 = subMenu2.$.overlay.querySelector('vaadin-menu-bar-submenu');
         item = subMenu2.$.overlay.querySelector('vaadin-context-menu-item');
         expect(item).to.be.ok;
         open(item);

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -34,7 +34,7 @@ module.exports = {
   registerHooks: function(context) {
     const saucelabsPlatformsMobile = [
       'iOS Simulator/iphone@12.2',
-      'iOS Simulator/iphone@10.3'
+      // 'iOS Simulator/iphone@10.3' FIXME(web-padawan): timeouts in SauceLabs
     ];
 
     const saucelabsPlatformsMicrosoft = [
@@ -60,7 +60,7 @@ module.exports = {
         browserName: 'chrome'
       },
       'iOS Simulator/ipad@12.2',
-      'iOS Simulator/iphone@10.3',
+      // 'iOS Simulator/iphone@10.3',
       'Windows 10/chrome@latest',
       'Windows 10/firefox@latest'
     ];


### PR DESCRIPTION
Fixes #73 

Extending a context-menu is needed in order to avoid adding a global `_onGlobalContextMenu` listener, which we would have to remove otherwise (which is weird and inconvenient).