### PR TITLE
fix: reset expanded button when closing on mobile

### DIFF
--- a/src/vaadin-menu-bar-interactions-mixin.html
+++ b/src/vaadin-menu-bar-interactions-mixin.html
@@ -33,7 +33,6 @@ This program is available under Apache License Version 2.0, available at https:/
 
     constructor() {
       super();
-      this.__boundOutsideClickListener = this.__outsideClickListener.bind(this);
       this.__boundOnContextMenuKeydown = this.__onContextMenuKeydown.bind(this);
     }
 
@@ -223,28 +222,6 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
-    __isOverlayClick(e) {
-      const path = e.composedPath();
-
-      const overlayContent = path.filter(node => {
-        return node.nodeType === Node.ELEMENT_NODE &&
-          node.getRootNode().host instanceof customElements.get('vaadin-context-menu-overlay') &&
-          node.getAttribute('id') === 'overlay';
-      })[0];
-
-      let overlay = overlayContent && overlayContent.getRootNode().host;
-
-      while (overlay) {
-        if (overlay === this._subMenu.$.overlay) {
-          return true;
-        } else if (overlay.parentOverlay) {
-          overlay = overlay.parentOverlay;
-        } else {
-          return false;
-        }
-      }
-    }
-
     _onMouseOver(e) {
       const button = this._getButtonFromEvent(e);
       if (button && button !== this._expandedButton) {
@@ -274,12 +251,6 @@ This program is available under Apache License Version 2.0, available at https:/
             this.__openSubMenu(button, e, {keepFocus: true});
           }
         }
-      }
-    }
-
-    __outsideClickListener(e) {
-      if (!this._getButtonFromEvent(e) && !this.__isOverlayClick(e)) {
-        this._close();
       }
     }
 

--- a/src/vaadin-menu-bar-interactions-mixin.html
+++ b/src/vaadin-menu-bar-interactions-mixin.html
@@ -225,7 +225,14 @@ This program is available under Apache License Version 2.0, available at https:/
 
     __isOverlayClick(e) {
       const path = e.composedPath();
-      let overlay = path.filter(node => node instanceof customElements.get('vaadin-context-menu-overlay'))[0];
+
+      const overlayContent = path.filter(node => {
+        return node.nodeType === Node.ELEMENT_NODE &&
+          node.getRootNode().host instanceof customElements.get('vaadin-context-menu-overlay') &&
+          node.getAttribute('id') === 'overlay';
+      })[0];
+
+      let overlay = overlayContent && overlayContent.getRootNode().host;
 
       while (overlay) {
         if (overlay === this._subMenu.$.overlay) {

--- a/src/vaadin-menu-bar-submenu.html
+++ b/src/vaadin-menu-bar-submenu.html
@@ -28,6 +28,19 @@ This program is available under Apache License Version 2.0, available at https:/
       _openedChanged(opened) {
         this.$.overlay.opened = opened;
       }
+
+
+      /**
+       * Overriding the public method to reset expanded button state.
+       */
+      close() {
+        super.close();
+
+        const host = this.getRootNode().host;
+        if (host && host.tagName.toLowerCase() === 'vaadin-menu-bar') {
+          host._close();
+        }
+      }
     }
 
     customElements.define(MenuBarSubmenuElement.is, MenuBarSubmenuElement);

--- a/src/vaadin-menu-bar-submenu.html
+++ b/src/vaadin-menu-bar-submenu.html
@@ -36,9 +36,9 @@ This program is available under Apache License Version 2.0, available at https:/
       close() {
         super.close();
 
-        const host = this.getRootNode().host;
-        if (host && host.tagName.toLowerCase() === 'vaadin-menu-bar') {
-          host._close();
+        // only handle 1st level submenu
+        if (this.hasAttribute('is-root')) {
+          this.getRootNode().host._close();
         }
       }
     }

--- a/src/vaadin-menu-bar.html
+++ b/src/vaadin-menu-bar.html
@@ -52,7 +52,7 @@ This program is available under Apache License Version 2.0, available at https:/
         <div class="dots"></div>
       </vaadin-menu-bar-button>
     </div>
-    <vaadin-menu-bar-submenu></vaadin-menu-bar-submenu>
+    <vaadin-menu-bar-submenu is-root></vaadin-menu-bar-submenu>
   </template>
 
   <script>

--- a/test/sub-menu.html
+++ b/test/sub-menu.html
@@ -397,6 +397,16 @@
           expect(buttons[0].hasAttribute('expanded')).to.be.false;
           expect(buttons[0].hasAttribute('focus-ring')).to.be.true;
         });
+
+        it('should remove expanded attribute when submenu closed on overlay backdrop click', async() => {
+          buttons[0].click();
+          await nextRender(subMenu);
+
+          subMenu.$.overlay.$.backdrop.dispatchEvent(new CustomEvent('click', {bubbles: true, composed: true}));
+          await nextRender(subMenu);
+          expect(subMenu.opened).to.be.false;
+          expect(buttons[0].hasAttribute('expanded')).to.be.false;
+        });
       });
     });
 


### PR DESCRIPTION
Fixes #66 

Previous check incorrectly considered backdrop clicks so that  `_close ` method wasn't called on mobile.

Note that the submenu was still closed due to outside click listener in `vaadin-context-menu` so apparently there are extra listeners which we might need to refactor.