### PR TITLE
Close sub-menu on disconnect

### DIFF
--- a/src/vaadin-menu-bar-interactions-mixin.html
+++ b/src/vaadin-menu-bar-interactions-mixin.html
@@ -75,6 +75,7 @@ This program is available under Apache License Version 2.0, available at https:/
     disconnectedCallback() {
       super.disconnectedCallback();
       document.removeEventListener('click', this.__boundOutsideClickListener, true);
+      this._close();
     }
 
     _themeChanged(theme) {

--- a/test/sub-menu.html
+++ b/test/sub-menu.html
@@ -87,6 +87,14 @@
         expect(subMenu.opened).to.be.false;
       });
 
+      it('should close sub-menu when menu is detached', async() => {
+        buttons[0].click();
+        await nextRender(subMenu);
+        expect(subMenu.opened).to.be.true;
+        menu.parentNode.removeChild(menu);
+        expect(subMenu.opened).to.be.false;
+      });
+
       it('should reopen sub-menu when different button with nested items clicked', async() => {
         buttons[0].click();
         await nextRender(subMenu);


### PR DESCRIPTION
Before this change the sub-menu was left open after detaching the menu-bar

Fixes vaadin/vaadin-menu-bar-flow#62