### PR TITLE
chore: relax context-menu version to 4.3.12

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.2.0",
     "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.0.0",
     "vaadin-button": "vaadin/vaadin-button#^2.1.4",
-    "vaadin-context-menu": "vaadin/vaadin-context-menu#^4.3.13",
+    "vaadin-context-menu": "vaadin/vaadin-context-menu#^4.3.12",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.4.1",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.2.2"
   },


### PR DESCRIPTION
I'm trying to update version in vaadin/vaadin-menu-bar-flow#65 and tests are failing.

It turns out this is because of Flow 2.0 and ContextMenuFlow 3.0.4 picked up.
The `vaadin-context-menu` version specified there is `4.3.12`, see 
https://github.com/vaadin/vaadin-context-menu-flow/releases/tag/3.0.4

This results in the following versions being installed:

```[INFO] Visited 714 classes. Took 866 ms.
[INFO] Added "@polymer/iron-icon": "3.0.1" line.
[INFO] Added "@vaadin/vaadin-context-menu": "4.3.12" line.
[INFO] Added "@vaadin/vaadin-icons": "4.3.1" line.
[INFO] Added "@vaadin/vaadin-menu-bar": "1.0.4" line.
[INFO] Added "@vaadin/vaadin-element-mixin": "~2.1.5" line.
[INFO] Added "@vaadin/vaadin-lumo-styles": "1.5.0" line.
[INFO] Added "@vaadin/vaadin-checkbox": "2.2.10" line.
[INFO] Added "@vaadin/vaadin-material-styles": "1.2.3" line
```

As a result, `vaadin-context-menu` is imported twice and the error is thrown.

We should either release `vaadin-context-menu-flow` 3.0.5 and update `vaadin-context-menu` to 4.3.15 there as well, or relax it here so that the error would go away.