### PR TITLE
fix: overflow feature now works correctly when menu-bar has "min-width: 0". (CP: #134)

### DIFF
--- a/src/vaadin-menu-bar-buttons-mixin.html
+++ b/src/vaadin-menu-bar-buttons-mixin.html
@@ -93,9 +93,30 @@ This program is available under Apache License Version 2.0, available at https:/
       const container = this._container;
       const buttons = this._buttons.slice(0);
       const overflow = buttons.pop();
-      const containerWidth = container.offsetWidth;
       const isRTL = this.getAttribute('dir') === 'rtl';
 
+      // reset all buttons in the menu bar and the overflow button
+      for (let i = 0; i < buttons.length; i++) {
+        const btn = buttons[i];
+        btn.disabled = btn.item.disabled;
+        btn.style.visibility = '';
+        btn.style.position = '';
+
+        // teleport item component back from "overflow" sub-menu
+        const item = btn.item && btn.item.component;
+        if (item instanceof HTMLElement && item.classList.contains('vaadin-menu-item')) {
+          btn.appendChild(item);
+          item.classList.remove('vaadin-menu-item');
+        }
+      }
+      overflow.item = {children: []};
+      this._hasOverflow = false;
+
+      if (this._subMenu.opened) {
+        this._subMenu.close();
+      }
+
+      // hide any overflowing buttons and put them in the 'overflow' button
       if (container.offsetWidth < container.scrollWidth) {
         this._hasOverflow = true;
 
@@ -103,13 +124,11 @@ This program is available under Apache License Version 2.0, available at https:/
         for (i = buttons.length; i > 0; i--) {
           const btn = buttons[i - 1];
           const btnStyle = getComputedStyle(btn);
-          if (btnStyle.visibility === 'hidden') {
-            continue;
-          }
 
           const btnWidth = btn.offsetWidth;
+          // if this button isn't overflowing, then the rest aren't either
           if (
-            (!isRTL && (btn.offsetLeft + btnWidth) < (containerWidth - overflow.offsetWidth)) ||
+            (!isRTL && (btn.offsetLeft + btnWidth) < (container.offsetWidth - overflow.offsetWidth)) ||
             (isRTL && btn.offsetLeft >= overflow.offsetWidth)
           ) {
             break;
@@ -124,47 +143,6 @@ This program is available under Apache License Version 2.0, available at https:/
         overflow.item = {
           children: buttons.filter((b, idx) => idx >= i).map(b => b.item)
         };
-      } else if (this._hasOverflow) {
-        if (this._subMenu.opened) {
-          this._subMenu.close();
-        }
-
-        for (let i = 0; i < buttons.length; i++) {
-          const btn = buttons[i];
-          const btnWidth = btn.getBoundingClientRect().width;
-
-          if (getComputedStyle(btn).visibility !== 'hidden') {
-            continue;
-          }
-
-          if (
-            (!isRTL && (overflow.offsetLeft + overflow.offsetWidth + btnWidth) < containerWidth) ||
-            (isRTL && (btnWidth < overflow.offsetLeft))
-          ) {
-            btn.disabled = btn.item.disabled;
-            btn.style.visibility = '';
-            btn.style.position = '';
-            btn.style.width = '';
-
-            // teleport item component back from "overflow" sub-menu
-            const item = btn.item && btn.item.component;
-            if (item instanceof HTMLElement && item.classList.contains('vaadin-menu-item')) {
-              btn.appendChild(item);
-              item.classList.remove('vaadin-menu-item');
-            }
-
-            overflow.item = {
-              children: buttons.filter((b, idx) => idx >= i + 1).map(b => b.item)
-            };
-
-            if (btn === buttons[buttons.length - 1]) {
-              this._hasOverflow = false;
-              overflow.item = {children: []};
-            }
-          } else {
-            break;
-          }
-        }
       }
     }
 

--- a/src/vaadin-menu-bar-buttons-mixin.html
+++ b/src/vaadin-menu-bar-buttons-mixin.html
@@ -94,6 +94,8 @@ This program is available under Apache License Version 2.0, available at https:/
       const buttons = this._buttons.slice(0);
       const overflow = buttons.pop();
       const isRTL = this.getAttribute('dir') === 'rtl';
+      // optional chaining is not supported in IE
+      const previouslyOverflowingButtons = (overflow.item && overflow.item.children && overflow.item.children.length) || 0;
 
       // reset all buttons in the menu bar and the overflow button
       for (let i = 0; i < buttons.length; i++) {
@@ -111,10 +113,6 @@ This program is available under Apache License Version 2.0, available at https:/
       }
       overflow.item = {children: []};
       this._hasOverflow = false;
-
-      if (this._subMenu.opened) {
-        this._subMenu.close();
-      }
 
       // hide any overflowing buttons and put them in the 'overflow' button
       if (container.offsetWidth < container.scrollWidth) {
@@ -143,6 +141,11 @@ This program is available under Apache License Version 2.0, available at https:/
         overflow.item = {
           children: buttons.filter((b, idx) => idx >= i).map(b => b.item)
         };
+      }
+      // optional chaining is not supported in IE
+      const currentlyOverflowingItems = (overflow.item && overflow.item.children && overflow.item.children.length) || 0;
+      if (previouslyOverflowingButtons !== currentlyOverflowingItems && this._subMenu.opened) {
+        this._subMenu.close();
       }
     }
 

--- a/src/vaadin-menu-bar-interactions-mixin.html
+++ b/src/vaadin-menu-bar-interactions-mixin.html
@@ -75,16 +75,6 @@ This program is available under Apache License Version 2.0, available at https:/
       document.removeEventListener('click', this.__boundOutsideClickListener, true);
     }
 
-    /**
-     * Can be called to manually notify a resizable and its descendant
-     * resizables of a resize change.
-     */
-    notifyResize() {
-      // NOTE: we have this method here to include it to TypeScript definitions.
-      // gen-typescript-declarations does not generate types for `mixinBehaviors`
-      super.notifyResize();
-    }
-
     /** @private */
     get __isRTL() {
       return this.getAttribute('dir') === 'rtl';
@@ -234,7 +224,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
     /** @private */
     __alignOverlayPosition(e) {
-      /* istanbul ignore if */
+      /* c8 ignore next */
       if (!this._expandedButton) {
         // When `openOnHover` is true, quickly moving cursor can close submenu,
         // so by the time when event listener gets executed button is null.

--- a/src/vaadin-menu-bar-interactions-mixin.html
+++ b/src/vaadin-menu-bar-interactions-mixin.html
@@ -75,6 +75,16 @@ This program is available under Apache License Version 2.0, available at https:/
       document.removeEventListener('click', this.__boundOutsideClickListener, true);
     }
 
+    /**
+     * Can be called to manually notify a resizable and its descendant
+     * resizables of a resize change.
+     */
+    notifyResize() {
+      // NOTE: we have this method here to include it to TypeScript definitions.
+      // gen-typescript-declarations does not generate types for `mixinBehaviors`
+      super.notifyResize();
+    }
+
     /** @private */
     get __isRTL() {
       return this.getAttribute('dir') === 'rtl';
@@ -224,7 +234,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
     /** @private */
     __alignOverlayPosition(e) {
-      /* c8 ignore next */
+      /* istanbul ignore if */
       if (!this._expandedButton) {
         // When `openOnHover` is true, quickly moving cursor can close submenu,
         // so by the time when event listener gets executed button is null.

--- a/test/basic.html
+++ b/test/basic.html
@@ -21,8 +21,8 @@
 
   <test-fixture id="responsive">
     <template>
-      <div style="display: flex;">
-        <vaadin-menu-bar style="min-width: 100%;"></vaadin-menu-bar>
+      <div style="display: block;">
+        <vaadin-menu-bar style="display: inline-block; max-width: 100%;"></vaadin-menu-bar>
       </div>
     </template>
   </test-fixture>

--- a/test/basic.html
+++ b/test/basic.html
@@ -19,6 +19,14 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="responsive">
+    <template>
+      <div style="display: flex;">
+        <vaadin-menu-bar style="min-width: 100%;"></vaadin-menu-bar>
+      </div>
+    </template>
+  </test-fixture>
+
   <script>
     function nextRender(target) {
       return new Promise(resolve => {
@@ -27,6 +35,18 @@
         });
       });
     }
+
+    const assertHidden = elem => {
+      const style = getComputedStyle(elem);
+      expect(style.visibility).to.equal('hidden');
+      expect(style.position).to.equal('absolute');
+    };
+
+    const assertVisible = elem => {
+      const style = getComputedStyle(elem);
+      expect(style.visibility).to.equal('visible');
+      expect(style.position).to.not.equal('absolute');
+    };
 
     describe('custom element definition', () => {
       let menu;
@@ -248,18 +268,6 @@
     describe('overflow button', () => {
       let menu, buttons, overflow;
 
-      const assertHidden = elem => {
-        const style = getComputedStyle(elem);
-        expect(style.visibility).to.equal('hidden');
-        expect(style.position).to.equal('absolute');
-      };
-
-      const assertVisible = elem => {
-        const style = getComputedStyle(elem);
-        expect(style.visibility).to.equal('visible');
-        expect(style.position).to.not.equal('absolute');
-      };
-
       beforeEach(async() => {
         menu = fixture('default');
 
@@ -373,6 +381,66 @@
           expect(overflow.item.children.length).to.equal(0);
           done();
         });
+      });
+
+      it('should hide overflow button and reset its items when all buttons fit after changing items', async() => {
+        // see https://github.com/vaadin/vaadin-menu-bar/issues/133
+        menu.items = [{text: 'Item 1'}, {text: 'Item 2'}];
+        await nextRender(menu);
+        buttons = menu._buttons;
+        overflow = buttons[2];
+        assertVisible(buttons[1]);
+
+        expect(overflow.hasAttribute('hidden')).to.be.true;
+        expect(overflow.item.children.length).to.equal(0);
+      });
+    });
+
+    describe('responsive behaviour in container', () => {
+      let container, menu, buttons, overflow;
+
+      beforeEach(async() => {
+        container = fixture('responsive');
+        menu = container.firstElementChild;
+
+        container.style.width = '250px';
+
+        menu.items = [
+          {text: 'Item 1'},
+          {text: 'Item 2'},
+          {text: 'Item 3'},
+          {text: 'Item 4'},
+          {text: 'Item 5', disabled: true}
+        ];
+        await nextRender(menu);
+        buttons = menu._buttons;
+        overflow = buttons[buttons.length - 1];
+      });
+
+      it('should hide overflow button and reset its items when all buttons fit ', async() => {
+        // must work even if menu-bar won't automatically resize to a larger size
+        // when more space becomes available
+        // see https://github.com/vaadin/vaadin-menu-bar/issues/130
+        menu.style.minWidth = '0';
+        container.style.width = '150px';
+        menu.notifyResize();
+        await nextRender(container);
+        assertHidden(buttons[2]);
+        expect(buttons[2].disabled).to.be.true;
+        assertHidden(buttons[3]);
+        expect(buttons[3].disabled).to.be.true;
+
+        container.style.width = '390px';
+        menu.notifyResize();
+        await nextRender(container);
+        assertVisible(buttons[2]);
+        expect(buttons[2].disabled).to.not.be.true;
+        assertVisible(buttons[3]);
+        expect(buttons[3].disabled).to.not.be.true;
+        assertVisible(buttons[4]);
+        expect(buttons[4].disabled).to.be.true;
+        expect(overflow.hasAttribute('hidden')).to.be.true;
+        expect(overflow.item.children.length).to.equal(0);
       });
     });
 


### PR DESCRIPTION
**Cherry-pick** for #134 

add a new test to check fix for the menubar not growing back on resizing (#130).

* add new fixture and test

check if the overflow button is hidden after changing the items array of the menubar

Co-authored-by: web-padawan <iamkulykov@gmail.com>