### PR TITLE
fix: focus item on click caused by Enter or Space keys

### DIFF
--- a/src/vaadin-menu-bar-button.html
+++ b/src/vaadin-menu-bar-button.html
@@ -27,6 +27,19 @@ This program is available under Apache License Version 2.0, available at https:/
       static get is() {
         return 'vaadin-menu-bar-button';
       }
+
+      /** @protected */
+      ready() {
+        super.ready();
+
+        this.addEventListener('keydown', e => {
+          this._activeKeyPressed = e.keyCode === 13 || e.keyCode === 32;
+
+          setTimeout(() => {
+            this._activeKeyPressed = null;
+          });
+        });
+      }
     }
 
     customElements.define(MenuBarButtonElement.is, MenuBarButtonElement);

--- a/src/vaadin-menu-bar-interactions-mixin.html
+++ b/src/vaadin-menu-bar-interactions-mixin.html
@@ -141,7 +141,7 @@ This program is available under Apache License Version 2.0, available at https:/
             // Menu opened previously, focus first item
             this._focusFirstItem();
           } else {
-            this.__openSubMenu(button, event);
+            this.__openSubMenu(button, true);
           }
         } else if (event.keyCode === 38) {
           // ArrowUp, prevent page scroll
@@ -150,7 +150,7 @@ This program is available under Apache License Version 2.0, available at https:/
             // Menu opened previously, focus last item
             this._focusLastItem();
           } else {
-            this.__openSubMenu(button, event, {focusLast: true});
+            this.__openSubMenu(button, true, {focusLast: true});
           }
         } else if (event.keyCode === 27 && button === this._expandedButton) {
           this._close(true);
@@ -202,7 +202,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
         this._focusButton(btn);
         if (wasExpanded && btn.item && btn.item.children) {
-          this.__openSubMenu(btn, event, {keepFocus: true});
+          this.__openSubMenu(btn, true, {keepFocus: true});
         }
       }
     }
@@ -272,7 +272,7 @@ This program is available under Apache License Version 2.0, available at https:/
       if (button && button !== this._expandedButton) {
         const isOpened = this._subMenu.opened;
         if (button.item.children && (this.openOnHover || isOpened)) {
-          this.__openSubMenu(button, e);
+          this.__openSubMenu(button, false);
         } else if (isOpened) {
           this._close();
         }
@@ -294,7 +294,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this._navigateByKey(e);
           const button = this.shadowRoot.activeElement;
           if (button && button.item && button.item.children) {
-            this.__openSubMenu(button, e, {keepFocus: true});
+            this.__openSubMenu(button, true, {keepFocus: true});
           }
         }
       }
@@ -310,12 +310,13 @@ This program is available under Apache License Version 2.0, available at https:/
       e.stopPropagation();
       const button = this._getButtonFromEvent(e);
       if (button) {
-        this.__openSubMenu(button, e);
+        // Focus first item on click event caused by Enter / Space.
+        this.__openSubMenu(button, button._activeKeyPressed);
       }
     }
 
     /** @private */
-    __openSubMenu(button, event, options = {}) {
+    __openSubMenu(button, keydown, options = {}) {
       const subMenu = this._subMenu;
       const item = button.item;
 
@@ -360,7 +361,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       // do not focus item when open not from keyboard
-      if (event.type !== 'keydown') {
+      if (!keydown) {
         this.__onceOpened(() => {
           subMenu.$.overlay.$.overlay.focus();
         });

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -16,6 +16,8 @@
     "home": false,
     "end": false,
     "esc": false,
+    "enter": false,
+    "space": false,
     "onceOpened": false,
     "sinon": false
   }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -26,6 +26,14 @@ window.esc = function(target) {
   MockInteractions.keyDownOn(target, 27, [], 'Escape');
 };
 
+window.enter = function(target) {
+  MockInteractions.keyDownOn(target, 13, [], 'Enter');
+};
+
+window.space = function(target) {
+  MockInteractions.keyDownOn(target, 32, [], ' ');
+};
+
 window.onceOpened = function(element) {
   return new Promise(resolve => {
     const listener = (e) => {

--- a/test/sub-menu.html
+++ b/test/sub-menu.html
@@ -170,6 +170,24 @@
         expect(subMenu.opened).to.be.false;
       });
 
+      (isIOS ? it.skip : it)('should focus the first item on button space', async() => {
+        space(buttons[0]);
+        buttons[0].click();
+        await onceOpened(subMenu);
+        await nextRender(subMenu);
+        const item = subMenu.$.overlay.querySelector('vaadin-context-menu-item');
+        expect(item.hasAttribute('focused')).to.be.true;
+      });
+
+      (isIOS ? it.skip : it)('should focus the first item on button enter', async() => {
+        enter(buttons[0]);
+        buttons[0].click();
+        await onceOpened(subMenu);
+        await nextRender(subMenu);
+        const item = subMenu.$.overlay.querySelector('vaadin-context-menu-item');
+        expect(item.hasAttribute('focused')).to.be.true;
+      });
+
       (isIOS ? it.skip : it)('should switch menubar button with items and open submenu on arrow left', async() => {
         arrowDown(buttons[0]);
         await onceOpened(subMenu);


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/web-components/issues/7142

Based on https://github.com/vaadin/web-components/pull/7111

Note: unlike the WC monorepo version (V22+), in V14 we have native `<button>` element handling `click` events, and we aren't calling `click()` manually on `keydown`. So I had to update tests to use `enter()` / `space()` followed by `click()`.

## Type of change

- Bugfix