### PR TITLE
fix: reset active key flag after the click event is fired

### DIFF
--- a/src/vaadin-menu-bar-button.html
+++ b/src/vaadin-menu-bar-button.html
@@ -34,7 +34,10 @@ This program is available under Apache License Version 2.0, available at https:/
 
         this.addEventListener('keydown', e => {
           this._activeKeyPressed = e.keyCode === 13 || e.keyCode === 32;
+        });
 
+        // Clear the flag after the click event is handled by menu-bar.
+        this.addEventListener('click', e => {
           setTimeout(() => {
             this._activeKeyPressed = null;
           });
@@ -45,4 +48,3 @@ This program is available under Apache License Version 2.0, available at https:/
     customElements.define(MenuBarButtonElement.is, MenuBarButtonElement);
   })();
 </script>
-


### PR DESCRIPTION
## Description

Follow-up to #166 

For some reason, <kbd>Space</kbd> key on the button in Chrome fires the `click` event after a timeout.
So, current approach of setting `_activeKeyPressed` works for <kbd>Enter</kbd> but not <kbd>Space</kbd>.

No test since we don't have an equivalent of `sendKeys` in the old test runner 😕 

## Type of change

- Bugfix / Refactor